### PR TITLE
mark fcgiapp contents as nothrow, @nogc

### DIFF
--- a/deimos/fastcgi/fcgiapp.d
+++ b/deimos/fastcgi/fcgiapp.d
@@ -4,6 +4,7 @@ import std.string;
 import std.c.stdarg;
 
 
+nothrow @nogc:
 extern (System) {
 
 /*

--- a/deimos/fastcgi/fcgiapp.d
+++ b/deimos/fastcgi/fcgiapp.d
@@ -4,7 +4,6 @@ import std.string;
 import std.c.stdarg;
 
 
-nothrow @nogc:
 extern (System) {
 
 /*
@@ -82,6 +81,9 @@ struct FCGX_Request {
     int flags;
     int listen_sock;
 }
+
+
+nothrow @nogc:
 
 /*
  *======================================================================


### PR DESCRIPTION
This module contains either POD or function stubs to a C library, so all can be marked as `nothrow` and `@nogc`.